### PR TITLE
adding engineer spritesheet

### DIFF
--- a/COSC438GameDesignNewREV/Content/engineerSpritesheet
+++ b/COSC438GameDesignNewREV/Content/engineerSpritesheet
@@ -1,0 +1,1 @@
+![Image of engineer spritesheet](https://cloud.githubusercontent.com/assets/6545648/11252658/57258808-8e05-11e5-84b9-bd9d29d4b72c.png)


### PR DESCRIPTION
two by three engineer spritesheet, provided file supports markdown. the image is available in the comment at least, so hopefully someone will be able to include it in an actual file in the repository

just for good measure:
![engineer](https://cloud.githubusercontent.com/assets/6545648/11252658/57258808-8e05-11e5-84b9-bd9d29d4b72c.png)
